### PR TITLE
Require different Names for each project

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -12,6 +12,7 @@ export default function Editor({
     const title = event.target.title.value;
     const text = event.target.text.value;
     const id = editorContent.id;
+    handleChangePage("my projects");
     saveProjects(title, text, id);
   };
   return (
@@ -31,7 +32,7 @@ export default function Editor({
           defaultValue={editorContent.text}
         ></TextField>
         <ButtonContainer>
-          <Button type="submit">Save</Button>
+          <Button type="submit">Save and Quit</Button>
           <Button onClick={() => handleChangePage("my projects")}>Load</Button>
         </ButtonContainer>
       </Form>

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -17,16 +17,19 @@ export default function Editor({
   return (
     <div>
       <Form onSubmit={handleSave}>
-        <TitleField type="text" name="title" id="title" placeholder="New Story">
-          {editorContent.title}
-        </TitleField>
+        <TitleField
+          type="text"
+          name="title"
+          id="title"
+          placeholder="New Story"
+          defaultValue={editorContent.title}
+        ></TitleField>
         <TextField
           name="text"
           id="text"
           placeholder="It was a dark and stormy night..."
-        >
-          {editorContent.text}
-        </TextField>
+          defaultValue={editorContent.text}
+        ></TextField>
         <ButtonContainer>
           <Button type="submit">Save</Button>
           <Button onClick={() => handleChangePage("my projects")}>Load</Button>

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -11,7 +11,8 @@ export default function Editor({
     event.preventDefault();
     const title = event.target.title.value;
     const text = event.target.text.value;
-    saveProjects(title, text);
+    const id = editorContent.id;
+    saveProjects(title, text, id);
   };
   return (
     <div>

--- a/components/NameTaken.js
+++ b/components/NameTaken.js
@@ -1,0 +1,30 @@
+import {TitleField} from "./Textfields";
+
+export default function NameTaken({nameTakenContent, saveProjects, setPage}) {
+  const handleSave = event => {
+    event.preventDefault();
+    const title = event.target.title.value;
+    const text = nameTakenContent.text;
+    const id = nameTakenContent.id;
+    setPage("my projects");
+    saveProjects(title, text, id);
+  };
+  return (
+    <div>
+      <h1>
+        A file with that name does allready exist. Please choose a different
+        name.
+      </h1>
+      <form onSubmit={handleSave}>
+        <TitleField
+          type="text"
+          name="title"
+          id="title"
+          placeholder="New Story"
+          defaultValue={nameTakenContent.title}
+        ></TitleField>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/components/NameTaken.js
+++ b/components/NameTaken.js
@@ -12,7 +12,7 @@ export default function NameTaken({nameTakenContent, saveProjects, setPage}) {
   return (
     <div>
       <h1>
-        A file with that name does allready exist. Please choose a different
+        A file with that name does already exist. Please choose a different
         name.
       </h1>
       <form onSubmit={handleSave}>

--- a/components/NameTaken.js
+++ b/components/NameTaken.js
@@ -5,33 +5,57 @@ export default function NameTaken({
   nameTakenContent,
   saveProjects,
   setNameTakenContent,
+  setPage,
+  setEditorContent,
 }) {
+  function handleReturnToEditor(title, text, id) {
+    setEditorContent({title: title, text: text, id: id});
+    setPage("editor");
+  }
+  function handleCloseWithoutSaving() {
+    setNameTakenContent({title: "", text: "", id: 0, taken: false});
+  }
   const handleSave = event => {
     event.preventDefault();
     const title = event.target.title.value;
     const text = nameTakenContent.text;
     const id = nameTakenContent.id;
-    saveProjects(title, text, id);
     setNameTakenContent({title: "", text: "", id: 0, taken: false});
+    saveProjects(title, text, id);
   };
   return (
     <Overlay>
-      <div>
-        <h1>
-          A file with that name does already exist. Please choose a different
-          name.
-        </h1>
+      <Dialog>
+        <h2>
+          A Story with that name does already exist. <br /> Please choose a
+          different name.
+        </h2>
         <form onSubmit={handleSave}>
           <TitleField
             type="text"
             name="title"
             id="title"
-            placeholder="New Story"
             defaultValue={nameTakenContent.title}
           ></TitleField>
-          <button type="submit">Save</button>
+          <ButtonBox>
+            <button type="submit">Save</button>
+            <button
+              onClick={() =>
+                handleReturnToEditor(
+                  nameTakenContent.title,
+                  nameTakenContent.text,
+                  nameTakenContent.id
+                )
+              }
+            >
+              Return to Editor
+            </button>
+            <button onClick={() => handleCloseWithoutSaving()}>
+              Close without saving
+            </button>
+          </ButtonBox>
         </form>
-      </div>
+      </Dialog>
     </Overlay>
   );
 }
@@ -48,4 +72,26 @@ const Overlay = styled.div`
   left: 0px;
   width: 100%;
   z-index: 10;
+`;
+
+const Dialog = styled.div`
+  --tw-bg-opacity: 1;
+  background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
+  border-radius: 0.75rem;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 2.5rem;
+  max-width: 100%;
+  width: 50vw;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+`;
+
+const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
 `;

--- a/components/NameTaken.js
+++ b/components/NameTaken.js
@@ -1,30 +1,51 @@
 import {TitleField} from "./Textfields";
+import styled from "styled-components";
 
-export default function NameTaken({nameTakenContent, saveProjects, setPage}) {
+export default function NameTaken({
+  nameTakenContent,
+  saveProjects,
+  setNameTakenContent,
+}) {
   const handleSave = event => {
     event.preventDefault();
     const title = event.target.title.value;
     const text = nameTakenContent.text;
     const id = nameTakenContent.id;
-    setPage("my projects");
     saveProjects(title, text, id);
+    setNameTakenContent({title: "", text: "", id: 0, taken: false});
   };
   return (
-    <div>
-      <h1>
-        A file with that name does already exist. Please choose a different
-        name.
-      </h1>
-      <form onSubmit={handleSave}>
-        <TitleField
-          type="text"
-          name="title"
-          id="title"
-          placeholder="New Story"
-          defaultValue={nameTakenContent.title}
-        ></TitleField>
-        <button type="submit">Save</button>
-      </form>
-    </div>
+    <Overlay>
+      <div>
+        <h1>
+          A file with that name does already exist. Please choose a different
+          name.
+        </h1>
+        <form onSubmit={handleSave}>
+          <TitleField
+            type="text"
+            name="title"
+            id="title"
+            placeholder="New Story"
+            defaultValue={nameTakenContent.title}
+          ></TitleField>
+          <button type="submit">Save</button>
+        </form>
+      </div>
+    </Overlay>
   );
 }
+
+const Overlay = styled.div`
+  --tw-bg-opacity: 1;
+  background-color: rgba(0, 0, 0, var(--tw-bg-opacity));
+  --tw-bg-opacity: 0.5;
+  height: 100%;
+  position: fixed;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+  width: 100%;
+  z-index: 10;
+`;

--- a/components/NameTaken.js
+++ b/components/NameTaken.js
@@ -11,6 +11,7 @@ export default function NameTaken({
   function handleReturnToEditor(title, text, id) {
     setEditorContent({title: title, text: text, id: id});
     setPage("editor");
+    setNameTakenContent({title: "", text: "", id: 0, taken: false});
   }
   function handleCloseWithoutSaving() {
     setNameTakenContent({title: "", text: "", id: 0, taken: false});

--- a/components/Projects.js
+++ b/components/Projects.js
@@ -5,22 +5,38 @@ export default function Projects({
   handleChangePage,
   setEditorContent,
 }) {
-  function handleLoadFile(title, text) {
-    setEditorContent({title: title, text: text});
+  function handleLoadFile(title, text, id) {
+    setEditorContent({title: title, text: text, id: id});
+    handleChangePage("editor");
+  }
+  function handleNewFile() {
+    const lastEntry = myProjects[myProjects.length - 1];
+    const newId = () => {
+      if (lastEntry.id == false) {
+        return 0;
+      } else {
+        return lastEntry.id + 1;
+      }
+    };
+    setEditorContent({title: "", text: "", id: newId});
     handleChangePage("editor");
   }
   return (
     <AllFiles>
       <FileBox>
         <h3>Start something new!</h3>
-        <button onClick={() => handleChangePage("editor")}>new document</button>
+        <button onClick={() => handleNewFile()}>new document</button>
       </FileBox>
       {myProjects.map(project => {
         return (
-          <FileBox key={project.title}>
+          <FileBox key={project.id}>
             <h3>{project.title}</h3>
             <article>{project.text}</article>
-            <button onClick={() => handleLoadFile(project.title, project.text)}>
+            <button
+              onClick={() =>
+                handleLoadFile(project.title, project.text, project.id)
+              }
+            >
               continue
             </button>
           </FileBox>

--- a/components/Projects.js
+++ b/components/Projects.js
@@ -11,13 +11,14 @@ export default function Projects({
   }
   function handleNewFile() {
     const lastEntry = myProjects[myProjects.length - 1];
-    const newId = () => {
-      if (lastEntry.id == false) {
+    function testEntry(entryToTest) {
+      if (entryToTest === undefined) {
         return 0;
       } else {
-        return lastEntry.id + 1;
+        return entryToTest.id + 1;
       }
-    };
+    }
+    const newId = testEntry(lastEntry);
     setEditorContent({title: "", text: "", id: newId});
     handleChangePage("editor");
   }
@@ -32,6 +33,7 @@ export default function Projects({
           <FileBox key={project.id}>
             <h3>{project.title}</h3>
             <article>{project.text}</article>
+            <p>{project.id}</p>
             <button
               onClick={() =>
                 handleLoadFile(project.title, project.text, project.id)

--- a/components/Projects.js
+++ b/components/Projects.js
@@ -33,6 +33,7 @@ export default function Projects({
           <FileBox key={project.id}>
             <h3>{project.title}</h3>
             <article>{project.text}</article>
+            <p>{project.id}</p>
             <button
               onClick={() =>
                 handleLoadFile(project.title, project.text, project.id)

--- a/components/Projects.js
+++ b/components/Projects.js
@@ -33,7 +33,6 @@ export default function Projects({
           <FileBox key={project.id}>
             <h3>{project.title}</h3>
             <article>{project.text}</article>
-            <p>{project.id}</p>
             <button
               onClick={() =>
                 handleLoadFile(project.title, project.text, project.id)

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,6 +18,7 @@ export default function Home() {
     title: "",
     text: "",
     id: 0,
+    taken: false,
   });
 
   function saveProjects(title, text, id) {
@@ -27,7 +28,8 @@ export default function Home() {
     const doesTitleExist = myProjects.find(project => project.title === title);
     const doesIdExist = myProjects.find(project => project.id === id);
     if (doesTitleExist !== undefined && doesIdExist === undefined) {
-      nameAlreadyTaken(title, text, id);
+      setNameTakenContent({title: title, text: text, id: id, taken: true});
+      return;
     }
     if (doesIdExist !== undefined) {
       const updatedFile = myProjects.map(project => {
@@ -41,18 +43,16 @@ export default function Home() {
       setMyProjects([...myProjects, {title: title, text: text, id: id}]);
     }
   }
-  function nameAlreadyTaken(title, text, id) {
-    setPage("name taken");
-    setNameTakenContent({title: title, text: text, id: id});
-  }
+
   return (
     <Body>
       <Navigation handleChangePage={handleChangePage} page={page} />
-      {page === "name taken" ? (
+      {nameTakenContent.taken === true ? (
         <NameTaken
           nameTakenContent={nameTakenContent}
           saveProjects={saveProjects}
           setPage={setPage}
+          setNameTakenContent={setNameTakenContent}
         />
       ) : (
         <></>

--- a/pages/index.js
+++ b/pages/index.js
@@ -53,6 +53,7 @@ export default function Home() {
           saveProjects={saveProjects}
           setPage={setPage}
           setNameTakenContent={setNameTakenContent}
+          setEditorContent={setEditorContent}
         />
       ) : (
         <></>

--- a/pages/index.js
+++ b/pages/index.js
@@ -25,10 +25,10 @@ export default function Home() {
       title = "Unnamed Document";
     }
     const doesTitleExist = myProjects.find(project => project.title === title);
-    if (doesTitleExist !== undefined) {
+    const doesIdExist = myProjects.find(project => project.id === id);
+    if (doesTitleExist !== undefined && doesIdExist === undefined) {
       nameAlreadyTaken(title, text, id);
     }
-    const doesIdExist = myProjects.find(project => project.id === id);
     if (doesIdExist !== undefined) {
       const updatedFile = myProjects.map(project => {
         if (project.id === doesIdExist.id) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,6 +16,8 @@ export default function Home() {
     if (title === "") {
       title = "Unnamed Document";
     }
+    const doesIdExist = myProjects.find(project => project.id === id);
+    console.log(doesIdExist);
     setMyProjects([...myProjects, {title: title, text: text, id: id}]);
   }
   const [editorContent, setEditorContent] = useState({title: "", text: ""});

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,8 +17,17 @@ export default function Home() {
       title = "Unnamed Document";
     }
     const doesIdExist = myProjects.find(project => project.id === id);
-    console.log(doesIdExist);
-    setMyProjects([...myProjects, {title: title, text: text, id: id}]);
+    if (doesIdExist !== undefined) {
+      const updatedFile = myProjects.map(project => {
+        if (project.id === doesIdExist.id) {
+          return {...project, title: title, text: text};
+        }
+        return project;
+      });
+      setMyProjects([...updatedFile]);
+    } else {
+      setMyProjects([...myProjects, {title: title, text: text, id: id}]);
+    }
   }
   const [editorContent, setEditorContent] = useState({title: "", text: ""});
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import Navigation from "../components/Navigation";
 import SetGoals from "../components/SetGoals";
 import Progress from "../components/Progress";
 import Projects from "../components/Projects";
+import NameTaken from "../components/NameTaken";
 import {useState} from "react";
 import styled from "styled-components";
 
@@ -12,9 +13,20 @@ export default function Home() {
     setPage(destination);
   }
   const [myProjects, setMyProjects] = useState([]);
+  const [editorContent, setEditorContent] = useState({title: "", text: ""});
+  const [nameTakenContent, setNameTakenContent] = useState({
+    title: "",
+    text: "",
+    id: 0,
+  });
+
   function saveProjects(title, text, id) {
     if (title === "") {
       title = "Unnamed Document";
+    }
+    const doesTitleExist = myProjects.find(project => project.title === title);
+    if (doesTitleExist !== undefined) {
+      nameAlreadyTaken(title, text, id);
     }
     const doesIdExist = myProjects.find(project => project.id === id);
     if (doesIdExist !== undefined) {
@@ -29,10 +41,22 @@ export default function Home() {
       setMyProjects([...myProjects, {title: title, text: text, id: id}]);
     }
   }
-  const [editorContent, setEditorContent] = useState({title: "", text: ""});
+  function nameAlreadyTaken(title, text, id) {
+    setPage("name taken");
+    setNameTakenContent({title: title, text: text, id: id});
+  }
   return (
     <Body>
       <Navigation handleChangePage={handleChangePage} page={page} />
+      {page === "name taken" ? (
+        <NameTaken
+          nameTakenContent={nameTakenContent}
+          saveProjects={saveProjects}
+          setPage={setPage}
+        />
+      ) : (
+        <></>
+      )}
       {page === "goals" ? <SetGoals /> : <></>}
       {page === "progress" ? <Progress /> : <></>}
       {page === "my projects" ? (

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,11 +12,11 @@ export default function Home() {
     setPage(destination);
   }
   const [myProjects, setMyProjects] = useState([]);
-  function saveProjects(title, text) {
+  function saveProjects(title, text, id) {
     if (title === "") {
       title = "Unnamed Document";
     }
-    setMyProjects([...myProjects, {title: title, text: text}]);
+    setMyProjects([...myProjects, {title: title, text: text, id: id}]);
   }
   const [editorContent, setEditorContent] = useState({title: "", text: ""});
   return (
@@ -49,5 +49,5 @@ export default function Home() {
 const Body = styled.div`
   background: #eeeeee;
   width: 100vw;
-  height: 100vh;
+  height: 150vh;
 `;


### PR DESCRIPTION
Added in this feature:
- App checks if the name of a story is already used
- if so, a popup appears, giving you the opportunity to change the name.

known issues:
- if you don't change the name the popup will reappear immediately, giving the impression that nothing has changed.
- feedback for button presses will be implemented in a later US